### PR TITLE
Add ability to specify custom replacement string

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,18 @@ var clean = require('strip-passwords')
 
 clean({ password: 'test' })
 // => { password: '****' }
+
+// or pass options
+clean({ password: 'test' }, {
+  replace: '____'
+})
+// => { password: '____' }
 ```
+
+### Options
+
+- `replace`: The string to use for replacement
+
 
 ## Author
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,9 @@
 
 module.exports = clean
 
-function clean(msg) {
+function clean(msg, opts) {
+  opts = opts || {}
+  var replace = opts.replace || '****'
   if (typeof msg !== 'object') {
     return msg
   }
@@ -10,7 +12,7 @@ function clean(msg) {
   for (var i = 0, len = keys.length; i < len; i++) {
     var key = keys[i]
     if (key === 'password') {
-      msg[key] = '****'
+      msg[key] = replace
     } else if (Array.isArray(msg[key])) {
       msg[key] = msg[key].map(clean);
     } else if (typeof msg[key] === 'object') {

--- a/test/test.js
+++ b/test/test.js
@@ -81,3 +81,19 @@ tests.forEach(function(tester) {
     t.end()
   })
 })
+
+test('should work with custom replace string', function(t) {
+  var input = {
+    name: 'test'
+  , password: 'test'
+  }
+  var exp = {
+    name: 'test'
+  , password: '____'
+  }
+  var out = clean(input, {
+    replace: '____'
+  })
+  t.deepEqual(out, exp)
+  t.end()
+})


### PR DESCRIPTION
By passing an object as the second parameter, one can change the
replacement string to be the value for the `replace` property.

R= @suitupalex 
